### PR TITLE
Add testURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "jest": "^23.3.0",
     "mocha": "^5.2.0"
+  },
+  "jest": {
+    "testURL": "http://localhost/"
   }
 }


### PR DESCRIPTION
In the other test, the error was happening.

```
yarn run v1.6.0                                                                                                                                       [25/763]
$ jest
 FAIL  __tests__/flatten.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.163s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```